### PR TITLE
feat(sale): Implementar módulo sale (vendas)

### DIFF
--- a/src/modules/client/client-service.ts
+++ b/src/modules/client/client-service.ts
@@ -1,3 +1,4 @@
+import type { ClientSession } from "mongoose";
 import { Conflict, NotFound } from "../../shared/utils/appErrors.ts";
 import type { IClient } from "./domain/client-interface.ts";
 import Client from "./infrastructure/client.ts";
@@ -55,8 +56,8 @@ class ClientService {
     return { clients, sizeCollection };
   };
 
-  listOne = async (id: string) => {
-    const client = await Client.findById(id);
+  listOne = async (id: string, session?: ClientSession) => {
+    const client = await Client.findById(id).session(session as ClientSession);
 
     if (!client) throw new NotFound("Cliente não encontrado.");
 

--- a/src/modules/products/product-service.ts
+++ b/src/modules/products/product-service.ts
@@ -1,8 +1,22 @@
+import type { ClientSession } from "mongoose";
 import { Conflict, NotFound } from "../../shared/utils/appErrors.ts";
 import type { IProduct } from "./domain/product-interface.ts";
 import Product from "./infrastructure/products.ts";
 
+type TypeProductMovement = {
+  product_id: string;
+  quantity: number;
+};
 class ProductService {
+  private buildOperationBulk = (dataArray: TypeProductMovement[], operation: "in" | "out") => {
+    return dataArray.map((item) => ({
+      updateOne: {
+        filter: { _id: item.product_id },
+        update: { $inc: { stock_quantity: operation === "in" ? +item.quantity : -item.quantity } },
+      },
+    }));
+  };
+
   private async productExist(product: any) {
     return await Product.findOne({
       _id: { $ne: product._id }, // ignora o próprio produto
@@ -23,6 +37,18 @@ class ProductService {
 
     return product;
   }
+
+  updateMany = async (data: any, operation: "in" | "out", session?: ClientSession) => {
+    const operationBulk = this.buildOperationBulk(data, operation);
+
+    await Product.bulkWrite(operationBulk, { ...(session && { session }) });
+  };
+
+  listIds = async (ids: string[], session?: ClientSession) => {
+    const products = await Product.find({ _id: { $in: ids } }).session(session as ClientSession);
+
+    return products;
+  };
 
   async update(data: Partial<IProduct>, id: string, userId: string) {
     // ! Propriedade packaging. A atualização dessa propriedade substitui o objeto inteiro, um merge com dot notation deve ser realizado para evitar.

--- a/src/modules/sale/domain/sale-interface.ts
+++ b/src/modules/sale/domain/sale-interface.ts
@@ -1,0 +1,18 @@
+import { Types } from "mongoose";
+
+export interface ISaleItem {
+  product_id: Types.ObjectId;
+  quantity: number;
+  unit_price: number;
+  product_name?: string;
+}
+
+export const STATUS_SALE = ["pending", "completed", "cancelled"] as const;
+export type TypeStatusSale = (typeof STATUS_SALE)[number];
+
+export interface ISale {
+  client_id: Types.ObjectId | string;
+  items: ISaleItem[];
+  total_value: number;
+  status: TypeStatusSale;
+}

--- a/src/modules/sale/infrastructure/sale.ts
+++ b/src/modules/sale/infrastructure/sale.ts
@@ -1,0 +1,45 @@
+import { Schema, model } from "mongoose";
+import { STATUS_SALE, type ISale, type ISaleItem } from "../domain/sale-interface.ts";
+
+// ── SaleItem sub-document ──────────────────────────────────────────────────
+
+const SaleItemSchema = new Schema<ISaleItem>(
+  {
+    product_id: { type: Schema.Types.ObjectId, ref: "Product", required: true },
+    quantity: { type: Number, required: true, min: 1 },
+    unit_price: { type: Number, required: true, min: 0 },
+  },
+  { _id: false },
+);
+
+// ── Sale document ──────────────────────────────────────────────────────────
+
+const SaleSchema = new Schema<ISale>(
+  {
+    client_id: { type: Schema.Types.ObjectId, ref: "Client", required: true },
+
+    items: {
+      type: [SaleItemSchema],
+      required: true,
+      validate: {
+        validator: (items: ISaleItem[]) => items.length > 0,
+        message: "A sale must contain at least one item.",
+      },
+    },
+
+    total_value: { type: Number, required: true, min: 0 },
+
+    status: {
+      type: String,
+      enum: STATUS_SALE,
+      required: true,
+      default: "pending",
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+const Sale = model<ISale>("Sale", SaleSchema);
+export default Sale;

--- a/src/modules/sale/middlewares/index.ts
+++ b/src/modules/sale/middlewares/index.ts
@@ -1,0 +1,2 @@
+export * from "./openSale-middleware.ts";
+export * from "./updateSale-middleware.ts";

--- a/src/modules/sale/middlewares/openSale-middleware.ts
+++ b/src/modules/sale/middlewares/openSale-middleware.ts
@@ -1,0 +1,26 @@
+import type { Request, Response, NextFunction } from "express";
+import { Key } from "../../shared/utils/validations/key.ts";
+
+export const openSale = (req: Request, res: Response, next: NextFunction) => {
+  const validators = {
+    client_id: { type: "string", required: true },
+    //total_value: { type: "number", required: true },
+    status: { type: "string", required: false }, // default: 'pending' no model
+
+    items: {
+      type: "array",
+      required: true,
+      items: "object",
+      fields: {
+        product_id: { type: "string", required: true },
+        quantity: { type: "number", required: true },
+        unit_price: { type: "number", required: true },
+        product_name: { type: "string", required: false },
+      },
+    },
+  };
+
+  Key.validate(validators, req.body);
+
+  next();
+};

--- a/src/modules/sale/middlewares/updateSale-middleware.ts
+++ b/src/modules/sale/middlewares/updateSale-middleware.ts
@@ -1,0 +1,13 @@
+import type { Request, Response, NextFunction } from "express";
+import { STATUS_SALE } from "../domain/sale-interface.ts";
+import { Key } from "../../shared/utils/validations/key.ts";
+
+export const updateSale = (req: Request, res: Response, next: NextFunction) => {
+  const validators = {
+    status: { type: "string", enum: STATUS_SALE, required: true },
+  };
+
+  Key.validate(validators, req.body);
+
+  next();
+};

--- a/src/modules/sale/sale-controller.ts
+++ b/src/modules/sale/sale-controller.ts
@@ -1,0 +1,55 @@
+import type { Request, Response } from "express";
+import service from "./sale-service.ts";
+import ResolveError from "../../shared/utils/resolveError.ts";
+class SalaController {
+  openSale = async (req: Request, res: Response) => {
+    try {
+      const body = req.body;
+      const sale = await service.create(body);
+
+      return res.status(201).json({ message: "Venda aberta com sucesso!", data: sale });
+    } catch (error) {
+      ResolveError.resolve(error);
+    }
+  };
+
+  list = async (req: Request, res: Response) => {
+    try {
+      const { sales, sizeCollection } = await service.list(req.query);
+
+      return res.status(200).json({
+        message: "Busca por vendas concluída com sucesso!",
+        data: sales,
+        sizeCollection,
+      });
+    } catch (error) {
+      ResolveError.resolve(error);
+    }
+  };
+
+  listById = async (req: Request, res: Response) => {
+    try {
+      const id = req.params.id as string;
+
+      const sale = await service.listById(id);
+
+      return res.status(200).json({ message: "Busca concluída com sucesso!", data: sale });
+    } catch (error) {
+      ResolveError.resolve(error);
+    }
+  };
+
+  update = async (req: Request, res: Response) => {
+    try {
+      const id = req.params.id as string;
+
+      const sale = await service.update(id, req.body.status);
+
+      return res.status(200).json({ message: "Pedido atualizado com sucesso!", data: sale });
+    } catch (error) {
+      ResolveError.resolve(error);
+    }
+  };
+}
+
+export default new SalaController();

--- a/src/modules/sale/sale-routes.ts
+++ b/src/modules/sale/sale-routes.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+
+import controller from "./sale-controller.ts";
+
+import { openSale, updateSale } from "./middlewares/index.ts";
+import { validateId } from "../shared/middlewares/validateId.ts";
+
+const routes = Router();
+
+routes.post("/", openSale, controller.openSale);
+routes.get("/", controller.list);
+routes.get("/:id", validateId, controller.listById);
+routes.patch("/:id/status", validateId, updateSale, controller.update);
+
+export default routes;

--- a/src/modules/sale/sale-service.ts
+++ b/src/modules/sale/sale-service.ts
@@ -1,0 +1,98 @@
+import mongoose from "mongoose";
+import type { ISale, TypeStatusSale } from "./domain/sale-interface.ts";
+import Sale from "./infrastructure/sale.ts";
+import { NotFound, UnprocessableEntity } from "../../shared/utils/appErrors.ts";
+import clientService from "../client/client-service.ts";
+import stockMovementService from "../stock/stock-services.ts";
+import productService from "../products/product-service.ts";
+
+class SaleService {
+  create = async (data: ISale) => {
+    const session = await mongoose.startSession();
+
+    if (data.items.length === 0)
+      throw new UnprocessableEntity(
+        "Não foi possível abrir venda: Pedido deve conter pelo menos um item.",
+      );
+
+    try {
+      await session.withTransaction(async () => {
+        if (!(await clientService.listOne(data.client_id as string, session)))
+          throw new NotFound("Cliente não encontrado.");
+
+        const productIds = data.items.map((item) => String(item.product_id));
+        const products = await productService.listIds(productIds, session);
+
+        for (const item of data.items) {
+          const product = products.find((p) => p._id.equals(item.product_id));
+          if (!product) throw new NotFound(`Produto não encontrado: ${item.product_name}`);
+        }
+
+        const totalValue = data.items.reduce((acc, product) => {
+          return acc + product.unit_price * product.quantity;
+        }, 0);
+
+        const saleData = { ...data, total_value: totalValue };
+
+        await stockMovementService.bulkOut(data, session);
+        const sale = await Sale.create([saleData], { session });
+
+        return sale;
+      });
+    } finally {
+      await session.endSession();
+    }
+  };
+
+  list = async (query: any) => {
+    const page = Number(query.page) || 1;
+    const limit = Number(query.limit) || 20;
+
+    const skip = (page - 1) * limit;
+
+    const filter: Record<string, any> = {};
+    const order: Record<string, any> = {};
+
+    if (query.order) {
+      query.order === "desc" ? (order.createdAt = -1) : (order.createdAt = +1);
+    }
+
+    if (query.start_date || query.end_date) {
+      filter.date = {
+        ...(query.start_date && { $gte: new Date(query.start_date) }),
+        ...(query.end_date && { $lte: new Date(query.end_date) }),
+      };
+    }
+
+    const sales = await Sale.find(filter)
+      .populate("client_id", "name phone address")
+      .sort(order)
+      .limit(limit)
+      .skip(skip)
+      .lean();
+
+    const sizeCollection = await Sale.countDocuments();
+
+    return { sales, sizeCollection };
+  };
+
+  listById = async (id: string) => {
+    const sale = await Sale.findById(id)
+      .populate("items.product_id")
+      .populate("client_id", "name phone address");
+
+    if (!sale) throw new NotFound("Pedido não encontrado.");
+
+    return sale;
+  };
+
+  update = async (id: string, status: TypeStatusSale) => {
+    const openSale = await Sale.findById(id);
+    if (!openSale) throw new NotFound("Pedido não encontrado.");
+
+    const sale = await Sale.findByIdAndUpdate(id, { status }, { new: true });
+    return sale;
+  };
+}
+
+export default new SaleService();

--- a/src/modules/shared/middlewares/validateId.ts
+++ b/src/modules/shared/middlewares/validateId.ts
@@ -1,10 +1,11 @@
 import type { Request, Response, NextFunction } from "express";
 import { Types } from "mongoose";
+import { BadRequest } from "../../../shared/utils/appErrors.ts";
 
 export const validateId = (req: Request, res: Response, next: NextFunction) => {
   const id = req.params.id as string;
 
-  if (!Types.ObjectId.isValid(id)) throw new Error("ID inválido.");
+  if (!Types.ObjectId.isValid(id)) throw new BadRequest("ID inválido.");
 
   next();
 };

--- a/src/modules/stock/stock-services.ts
+++ b/src/modules/stock/stock-services.ts
@@ -2,7 +2,11 @@ import StockMovement from "./infrastructure/stock.ts";
 import Product from "../products/infrastructure/products.ts";
 import type { IStockMovement } from "./domain/stock-interface.ts";
 import { NotFound, UnprocessableEntity } from "../../shared/utils/appErrors.ts";
+import type { ClientSession } from "mongoose";
 
+import productService from "../products/product-service.ts";
+
+type TypeSaleItem = { product_id: string; quantity: number; unit_price: number };
 class StockMovementService {
   list = async (query: any) => {
     const page = Number(query.page);
@@ -46,8 +50,8 @@ class StockMovementService {
     await StockMovement.insertMany(dataArray);
   };
 
-  bulkOut = async (data: any) => {
-    const dataArray: IStockMovement[] = data.products;
+  bulkOut = async (data: any, session?: ClientSession) => {
+    const dataArray: TypeSaleItem[] = data.items;
 
     const products = await Product.find({
       _id: { $in: dataArray.map((p) => p.product_id) },
@@ -82,16 +86,19 @@ class StockMovementService {
       }
     }
 
-    await Product.bulkWrite(
-      dataArray.map((item) => ({
-        updateOne: {
-          filter: { _id: item.product_id },
-          update: { $inc: { stock_quantity: -item.quantity } },
-        },
-      })),
-    );
+    const stockMovementArray = dataArray.map((product) => {
+      return {
+        product_id: product.product_id,
+        date: new Date(),
+        quantity: product.quantity,
+        type: "out",
+        note: "Débito de estoque por abertura de venda",
+      };
+    });
 
-    await StockMovement.insertMany(dataArray);
+    await productService.updateMany(dataArray, "out", session);
+
+    await StockMovement.insertMany(stockMovementArray, { ...(session && { session }) });
   };
 
   moveOut = async (data: IStockMovement) => {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -6,6 +6,7 @@ import userRoutes from "./modules/user/user-routes.ts";
 import productRoutes from "./modules/products/product-routes.ts";
 import stockMovementRoutes from "./modules/stock/stock-routes.ts";
 import clientRoutes from "./modules/client/client-routes.ts";
+import saleRoutes from "./modules/sale/sale-routes.ts";
 
 const routes = Router();
 
@@ -13,6 +14,7 @@ routes.use("/user", userRoutes);
 routes.use("/product", productRoutes);
 routes.use("/stock", stockMovementRoutes);
 routes.use("/client", clientRoutes);
+routes.use("/sale", saleRoutes);
 
 routes.use(launchError);
 


### PR DESCRIPTION
**O que foi feito**

Implementação completa do módulo `sales` cobrindo abertura, conclusão e cancelamento de vendas, com integração ao módulo `stock` e `product` para débito e estorno de estoque.

**Decisões técnicas**

- `total_value` é sempre calculado no service a partir dos itens — valor enviado pelo cliente é ignorado
- Abertura de venda usa MongoDB session/transaction para garantir atomicidade entre criação da venda e débito de estoque
- Cancelamento reverte débitos via `bulkIn` do `stockService` e registra movimentos do tipo `in`
- `product_name` pode ser enviado no payload como campo auxiliar não persistido, usado apenas para identificar o produto em mensagens de erro

**Arquivos alterados**

```
criados:
  server/src/modules/sales/domain/sale.interface.ts
  server/src/modules/sales/infrastructure/sales.ts
  server/src/modules/sales/sales-service.ts
  server/src/modules/sales/sales-controller.ts
  server/src/modules/sales/sales-routes.ts
  server/src/modules/sales/middlewares/createSale-middleware.ts

alterados:
  server/src/routes.ts
```

**Checklist**

- [x]  Segue o padrão de módulos (`06 — Padrão de Módulos`)
- [x]  Validações cobertas por middleware
- [x]  Erros tratados via `ResolveError.resolve()`
- [x]  Rota registrada em `routes.ts`
- [x]  Testado localmente