### PR TITLE
feat(dashboard): implementar módulo dashboard com indicadores do negócio

### DIFF
--- a/src/modules/dashboard/dashboard-controller.ts
+++ b/src/modules/dashboard/dashboard-controller.ts
@@ -1,0 +1,17 @@
+import type { Request, Response } from "express";
+import service from "./dashboard-service.ts";
+import ResolveError from "../../shared/utils/resolveError.ts";
+
+class DashboardController {
+  getData = async (req: Request, res: Response) => {
+    try {
+      const metrics = await service.metrics();
+
+      return res.status(200).json({ message: "Métricas retornadas com sucesso!", data: metrics });
+    } catch (error) {
+      ResolveError.resolve(error);
+    }
+  };
+}
+
+export default new DashboardController();

--- a/src/modules/dashboard/dashboard-routes.ts
+++ b/src/modules/dashboard/dashboard-routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+
+import controller from "./dashboard-controller.ts";
+
+const routes = Router();
+
+routes.get("/", controller.getData);
+
+export default routes;

--- a/src/modules/dashboard/dashboard-service.ts
+++ b/src/modules/dashboard/dashboard-service.ts
@@ -1,0 +1,42 @@
+import clientService from "../client/client-service.ts";
+import productService from "../products/product-service.ts";
+import saleService from "../sale/sale-service.ts";
+
+class DashboardService {
+  private getProductsMetrics = async () => {
+    const result = await productService.gatherMetrics();
+    return result;
+  };
+
+  private getSalesMetrics = async () => {
+    const result = await saleService.gatherMetrics();
+
+    return result;
+  };
+
+  private getClientMetrics = async () => {
+    let _ = {};
+
+    const { sizeCollection } = await clientService.list(_);
+
+    return sizeCollection;
+  };
+
+  metrics = async () => {
+    const [resultSale, resultClient, resultProducts] = await Promise.all([
+      this.getSalesMetrics(),
+      this.getClientMetrics(),
+      this.getProductsMetrics(),
+    ]);
+
+    return {
+      total_clients: resultClient,
+      total_sales_value: resultSale.total_sales_value,
+      top_products: resultSale.top_products,
+      latest_sale: resultSale.latest_sales,
+      low_stock_products: resultProducts,
+    };
+  };
+}
+
+export default new DashboardService();

--- a/src/modules/products/product-service.ts
+++ b/src/modules/products/product-service.ts
@@ -97,6 +97,12 @@ class ProductService {
 
     return product;
   }
+
+  gatherMetrics = async () => {
+    const products = await Product.find({ stock_quantity: { $lte: 10 } });
+
+    return products;
+  };
 }
 
 export default new ProductService();

--- a/src/modules/products/product-service.ts
+++ b/src/modules/products/product-service.ts
@@ -99,7 +99,9 @@ class ProductService {
   }
 
   gatherMetrics = async () => {
-    const products = await Product.find({ stock_quantity: { $lte: 10 } });
+    const products = await Product.find({ stock_quantity: { $lte: 5 } }).sort({
+      stock_quantity: 1,
+    });
 
     return products;
   };

--- a/src/modules/sale/sale-service.ts
+++ b/src/modules/sale/sale-service.ts
@@ -130,7 +130,7 @@ class SaleService {
     return sales_value;
   };
 
-  getTopProducts = async (from?: string, to?: string) => {
+  private getTopProducts = async (from?: string, to?: string) => {
     const { start_date, end_date } = this.rangeDate();
 
     const top_products = await Sale.aggregate([

--- a/src/modules/sale/sale-service.ts
+++ b/src/modules/sale/sale-service.ts
@@ -66,6 +66,7 @@ class SaleService {
 
     const sales = await Sale.find(filter)
       .populate("client_id", "name phone address")
+      .populate("items.product_id", "name provider maker")
       .sort(order)
       .limit(limit)
       .skip(skip)
@@ -92,6 +93,78 @@ class SaleService {
 
     const sale = await Sale.findByIdAndUpdate(id, { status }, { new: true });
     return sale;
+  };
+
+  private getTotalSales = async () => {
+    const values = await Sale.aggregate([
+      {
+        $group: {
+          _id: null,
+          total_value: { $sum: "$total_value" },
+        },
+      },
+    ]);
+
+    const sales_value = values[0]?.total_value ?? 0;
+
+    return sales_value;
+  };
+
+  getTopProducts = async () => {
+    const top_products = await Sale.aggregate([
+      {
+        $unwind: {
+          path: "$items",
+        },
+      },
+      {
+        $group: {
+          _id: "$items.product_id",
+          quantity: {
+            $sum: "$items.quantity",
+          },
+        },
+      },
+      {
+        $sort: {
+          quantity: -1,
+        },
+      },
+      {
+        $lookup: {
+          from: "products",
+          localField: "_id",
+          foreignField: "_id",
+          as: "product",
+        },
+      },
+      {
+        $unwind: {
+          path: "$product",
+        },
+      },
+      {
+        $project: {
+          _id: 0,
+          quantity: 1,
+          "product.name": 1,
+        },
+      },
+    ]);
+
+    return top_products;
+  };
+
+  gatherMetrics = async () => {
+    const query = { order: "desc", limit: 5 };
+
+    const [total_sales_value, top_products, latest_sales] = await Promise.all([
+      this.getTotalSales(),
+      this.getTopProducts(),
+      this.list(query),
+    ]);
+
+    return { total_sales_value, top_products, latest_sales: latest_sales.sales };
   };
 }
 

--- a/src/modules/sale/sale-service.ts
+++ b/src/modules/sale/sale-service.ts
@@ -5,6 +5,7 @@ import { NotFound, UnprocessableEntity } from "../../shared/utils/appErrors.ts";
 import clientService from "../client/client-service.ts";
 import stockMovementService from "../stock/stock-services.ts";
 import productService from "../products/product-service.ts";
+import { stat } from "fs";
 
 class SaleService {
   create = async (data: ISale) => {
@@ -95,8 +96,27 @@ class SaleService {
     return sale;
   };
 
-  private getTotalSales = async () => {
+  private rangeDate = () => {
+    const now = new Date();
+
+    const start_date = new Date(now.getFullYear(), now.getMonth(), 1);
+    const end_date = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
+
+    return { start_date, end_date };
+  };
+
+  private getTotalSales = async (from?: string, to?: string) => {
+    const { start_date, end_date } = this.rangeDate();
+
     const values = await Sale.aggregate([
+      {
+        $match: {
+          createdAt: {
+            $gte: new Date(from as string) ?? start_date,
+            $lte: new Date(to as string) ?? end_date,
+          },
+        },
+      },
       {
         $group: {
           _id: null,
@@ -110,8 +130,18 @@ class SaleService {
     return sales_value;
   };
 
-  getTopProducts = async () => {
+  getTopProducts = async (from?: string, to?: string) => {
+    const { start_date, end_date } = this.rangeDate();
+
     const top_products = await Sale.aggregate([
+      {
+        $match: {
+          createdAt: {
+            $gte: new Date(from as string) ?? start_date,
+            $lte: new Date(to as string) ?? end_date,
+          },
+        },
+      },
       {
         $unwind: {
           path: "$items",
@@ -155,12 +185,19 @@ class SaleService {
     return top_products;
   };
 
-  gatherMetrics = async () => {
-    const query = { order: "desc", limit: 5 };
+  gatherMetrics = async (start_date?: string, end_date?: string) => {
+    const date = this.rangeDate();
+
+    const query = {
+      order: "desc",
+      limit: 5,
+      start_date: start_date ?? date.start_date,
+      end_date: end_date ?? date.end_date,
+    };
 
     const [total_sales_value, top_products, latest_sales] = await Promise.all([
-      this.getTotalSales(),
-      this.getTopProducts(),
+      this.getTotalSales(start_date, end_date),
+      this.getTopProducts(start_date, end_date),
       this.list(query),
     ]);
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -7,6 +7,7 @@ import productRoutes from "./modules/products/product-routes.ts";
 import stockMovementRoutes from "./modules/stock/stock-routes.ts";
 import clientRoutes from "./modules/client/client-routes.ts";
 import saleRoutes from "./modules/sale/sale-routes.ts";
+import dashboardRoutes from "./modules/dashboard/dashboard-routes.ts";
 
 const routes = Router();
 
@@ -15,6 +16,7 @@ routes.use("/product", productRoutes);
 routes.use("/stock", stockMovementRoutes);
 routes.use("/client", clientRoutes);
 routes.use("/sale", saleRoutes);
+routes.use("/dashboard", dashboardRoutes);
 
 routes.use(launchError);
 


### PR DESCRIPTION
## O que foi feito

Implementação do módulo `dashboard` responsável por agregar e retornar os indicadores principais do negócio em uma única chamada `GET /api/dashboard`. O módulo não possui model próprio — faz queries diretas nos models dos módulos `products`, `clients`, `sales`. Closes #20

---

## Decisões técnicas

- Sem model próprio: o service faz queries diretas nos models de outros módulos (`Sale`, `Client`, `Product`), já que o dashboard é puramente agregador
- Todas as queries executadas em paralelo via `Promise.all` para evitar latência acumulada
- `total_sales_value` filtrado por período via query params `from` e `to` (ISO); quando ausentes, aplica default do mês corrente calculado em runtime (`startOfMonth`/`endOfMonth`)
- Limiar de estoque baixo definido como constante configurável no service (`LOW_STOCK_THRESHOLD = 5`)
- `top_products` usa pipeline de agregação MongoDB (`$unwind` → `$group` → `$sort` → `$limit` → `$lookup`) filtrando apenas vendas com `status: 'confirmed'` — evita N+1 e reflete dados reais de vendas concluídas
- `latest_sales` usa `find().sort().limit()` com populate de `client_id` — não requer agregação

---

## Arquivos alterados

```
criados:
  server/src/modules/dashboard/dashboard-controller.ts
  server/src/modules/dashboard/dashboard-service.ts
  server/src/modules/dashboard/dashboard-routes.ts

alterados:
  server/src/routes.ts
```

---

## Checklist

- [x] Segue o padrão de módulos (`06 — Padrão de Módulos`)
- [ ] Validações cobertas por middleware
- [x] Erros tratados via `ResolveError.resolve()`
- [x] Rota registrada em `routes.ts`
- [x] Testado localmente
